### PR TITLE
add commonregex module to the setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setup(
     py_modules=['gitmoney'],
         install_requires=[
             'Click',
+            'commonregex',
     ],
     entry_points='''
         [console_scripts]


### PR DESCRIPTION
Setup worked but couldn't run gitmoney without installing commonregex so added it to the modules installed by setup.py.