### PR TITLE
social/about-git-money: Fix typo

### DIFF
--- a/social/about-git-money.md
+++ b/social/about-git-money.md
@@ -15,7 +15,7 @@ because it is hard.
 
 We've said it before and we'll say it again - it doesn't matter where you're
 from or who you are. We believe in the right to work anywhere on whatever you
-want. It doesn't matter your gender, your education, your social or spirtiual
+want. It doesn't matter your gender, your education, your social or spiritual
 beliefs or your skin color.
 
 We are the Bitcoin Legion and our home is Earth.


### PR DESCRIPTION
This commit fixes a small typo in the 'About Git Money' document.