### PR TITLE
setup webhook on wallet creation

### DIFF
--- a/app/multisig_wallet.py
+++ b/app/multisig_wallet.py
@@ -89,8 +89,14 @@ class multisig_wallet(object):
             print('Wallet ID: ' + walletId + '\n')
             print('Your wallet config file can be found at: ' + DEFAULT_WALLET_PATH)
 
+        try:
+            multisig_wallet.set_webhook(user, '/webhooks', 0)
+        except:
+            print('Could not set webhook')
+        
         print('Created a new wallet for: ' + username)       
         print(r.json()['wallet']['id'])
+
         return r.json()['wallet']['id']
         
     @staticmethod


### PR DESCRIPTION
Resolves #122 
Bitcoin Address: 12E31FZd3u5D5de6xSRAzezMG14fLeCHo5
Description: This PR setups up the BitGo Webhooks during wallet creation process to fire to `/webhooks`.
